### PR TITLE
fix: certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN go build -tags netgo -ldflags '-s -w' -o server
 FROM debian:bookworm-slim
 WORKDIR /app/
 COPY --from=builder /build/server /app/
+RUN apt-get update && apt-get install -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/static/ /app/static/
 
 EXPOSE 8000


### PR DESCRIPTION
Add `ca-certificates` in the final build stage to avoid certificate invalidation errors
